### PR TITLE
Staging: prefer config files in tarball over those already provisioned on the server.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'debugger', require: nil
-# Use my fork until https://github.com/guard/guard-minitest/pull/65 is released
+gem 'pry', require: nil
 gem 'guard-minitest', '>= 1.0.0.rc.2'
 gem 'terminal-notifier-guard'

--- a/lib/egads/group.rb
+++ b/lib/egads/group.rb
@@ -52,9 +52,12 @@ module Egads
 
     def symlink(src, dest)
       raise ArgumentError.new("#{src} is not a file") unless File.file?(src)
-      say_status :symlink, "from #{src} to #{dest}"
-      FileUtils.ln_s(src, dest)
-    #rescue Errno::EEXIST # This could happen, don't bother rescuing it.
+      if File.file?(dest)
+        say_status :symlink, "Skipping #{src}, #{dest} already exists."
+      else
+        say_status :symlink, "from #{src} to #{dest}"
+        FileUtils.ln_s(src, dest)
+      end
     end
   end
 end

--- a/lib/egads/group.rb
+++ b/lib/egads/group.rb
@@ -53,7 +53,8 @@ module Egads
     def symlink(src, dest)
       raise ArgumentError.new("#{src} is not a file") unless File.file?(src)
       say_status :symlink, "from #{src} to #{dest}"
-      FileUtils.ln_sf(src, dest)
+      FileUtils.ln_s(src, dest)
+    #rescue Errno::EEXIST # This could happen, don't bother rescuing it.
     end
   end
 end

--- a/lib/egads/version.rb
+++ b/lib/egads/version.rb
@@ -1,3 +1,3 @@
 module Egads
-  VERSION = '4.0.0.pre'
+  VERSION = '4.0.0'
 end

--- a/lib/egads/version.rb
+++ b/lib/egads/version.rb
@@ -1,3 +1,3 @@
 module Egads
-  VERSION = '3.2.1'
+  VERSION = '4.0.0.pre'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,8 @@ Fog.mock!
 SHA = 'deadbeef' * 5 # Test git sha
 
 begin
-  require 'debugger'
+  require 'pry'
 rescue LoadError
-  puts "Skipping debugger"
 end
 
 # Extensions


### PR DESCRIPTION
This changes the symlink behavior.

If a config file (like `config/foo.yml`) exists in _both_ the deployed tarball and in the system shared config folder, we used to overwrite the tarball config with a symlink to the system shared config.

This changes that behavior to leave the file in the tarball intact.
