### PR TITLE
Remove unf dependency.

### DIFF
--- a/egads.gemspec
+++ b/egads.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.rdoc_options      = ["--charset=UTF-8"]
 
   s.add_dependency "fog-aws", "~> 0.7"
-  s.add_dependency "unf" # Avoid fog warning about string encodings
   s.add_dependency "thor"
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest"

--- a/lib/egads/version.rb
+++ b/lib/egads/version.rb
@@ -1,3 +1,3 @@
 module Egads
-  VERSION = '3.3.0'
+  VERSION = '3.3.1'
 end


### PR DESCRIPTION
It’s obsolete as of https://github.com/fog/fog/pull/2791

FYI @tiegz 