### PR TITLE
Support shallow clones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 sudo: false # Opt-in to container infrastructure
 rvm:
-  - 1.9.3
-  - 2.1.6
-  - 2.2.2
+  - 2.2.4
+  - 2.3.0

--- a/lib/egads/command/build.rb
+++ b/lib/egads/command/build.rb
@@ -3,9 +3,8 @@ module Egads
     include Thor::Actions
     include LocalHelpers
 
-    desc "[local] Compiles a deployable patch of the current commit and uploads it to S3"
+    desc "[local] Compiles a deployable tarball of the current commit and uploads it to S3"
     class_option :force, type: :boolean, aliases: '-f', default: false, banner: "Build and overwrite existing tarball on S3"
-    class_option :seed, type: :boolean, default: false, banner: "Builds and tags a complete tarball for more efficient patches"
     class_option 'no-upload', type: :boolean, default: false, banner: "Don't upload the tarball to S3"
     argument :rev, type: :string, default: 'HEAD', desc: 'git revision to build'
 
@@ -15,12 +14,12 @@ module Egads
       say_status :rev, "#{rev} parsed to #{sha}"
 
       unless should_build?
-        say_status :done, "#{build_type} tarball for #{sha} already exists. Pass --force to rebuild."
+        say_status :done, "tarball for #{sha} already exists. Pass --force to rebuild."
         exit 0
       end
 
       exit 1 unless can_build?
-      say_status :build, "Making #{build_type} tarball for #{sha}", :yellow
+      say_status :build, "Making tarball for #{sha}", :yellow
     end
 
     def run_before_build_hooks
@@ -45,21 +44,7 @@ module Egads
     end
 
     def make_tarball
-      if options[:seed]
-        # Seed tarball
-        run_with_code "git archive #{build_sha} --output #{tarball.local_tar_path}"
-      else
-        # Patch tarball
-        seed_ref = "refs/remotes/origin/#{Config.seed_branch}"
-        # NB: the seed tarball is named after the parent of seed tag
-        seed_parent = run_with_code("git rev-parse --verify #{seed_ref}^").strip
-        File.open('egads-seed', 'w') {|f| f << seed_parent + "\n" }
-        patch_files = [patch_path, 'egads-seed']
-        run_with_code "git diff --binary #{seed_ref} #{build_sha} > #{patch_path}"
-        run_with_code "tar -zcf #{tarball.local_tar_path} #{patch_files * ' '}"
-        patch_files.each {|f| File.delete(f) }
-      end
-
+      run_with_code "git archive #{build_sha} --output #{tarball.local_tar_path}"
     end
 
     def run_after_build_hooks
@@ -67,13 +52,7 @@ module Egads
     end
 
     def upload
-      invoke(Egads::Upload, [sha], force: options[:force], seed: options[:seed]) unless options['no-upload']
-    end
-
-    def push_seed
-      if options[:seed]
-        run_with_code "git push -f origin #{build_sha}:refs/heads/#{Config.seed_branch}"
-      end
+      invoke(Egads::Upload, [sha], force: options[:force]) unless options['no-upload']
     end
 
     module BuildHelpers
@@ -104,10 +83,6 @@ module Egads
 
       def patch_path
         "#{sha}.patch"
-      end
-
-      def build_type
-        options[:seed] ? 'seed' : 'patch'
       end
 
       def error(message)

--- a/lib/egads/command/extract.rb
+++ b/lib/egads/command/extract.rb
@@ -19,14 +19,22 @@ module Egads
 
         do_extract patch_path
 
-        # Download seed
-        self.seed_sha = Pathname.new(patch_dir).join("egads-seed").read.strip
-        self.seed_path = File.join(RemoteConfig.seed_dir, "#{seed_sha}.tar.gz")
-        do_download(seed_sha, seed_path, 'seed')
+        # If the seed path exists, the patch was build w/ egads <= 4.0
+        # Newer patch files include the seed
+        seed_pointer = Pathname.new(patch_dir).join("egads-seed")
+        if seed_pointer.exist?
+          # Download seed
+          self.seed_sha = seed_pointer.read.strip
+          self.seed_path = File.join(RemoteConfig.seed_dir, "#{seed_sha}.tar.gz")
+          do_download(seed_sha, seed_path, 'seed')
 
-        do_extract seed_path
+          do_extract seed_path
 
-        apply_patch
+          apply_patch
+        else
+          say_status :done, 'Patch tarball is complete, no seed to extract.'
+        end
+
         finish_extraction
       else
         say_status :done, "#{sha} already extracted. Use --force to overwrite"

--- a/lib/egads/command/upload.rb
+++ b/lib/egads/command/upload.rb
@@ -4,14 +4,12 @@ module Egads
 
     desc "[local, plumbing] Uploads a tarball for SHA to S3"
     argument :sha, type: :string, required: true, desc: 'git SHA to upload'
-    class_option :seed, type: :boolean, default: false, banner: "Uploads a seed tarball"
-
 
     attr_reader :sha
     def upload
       @sha = sha
       size = File.size(path)
-      type = options[:seed] ? 'seed' : 'patch'
+      type = 'patch'
 
       say_status :upload, "Uploading #{type} tarball (%.1f MB)" % (size.to_f / 2**20), :yellow
       duration = Benchmark.realtime do
@@ -24,7 +22,7 @@ module Egads
 
     private
     def tarball
-      @tarball ||= S3Tarball.new(sha, seed: options[:seed])
+      @tarball ||= S3Tarball.new(sha, seed: false)
     end
 
     def path

--- a/lib/egads/version.rb
+++ b/lib/egads/version.rb
@@ -1,3 +1,3 @@
 module Egads
-  VERSION = '4.0.0'
+  VERSION = '5.0.0'
 end

--- a/spec/egads_build_spec.rb
+++ b/spec/egads_build_spec.rb
@@ -4,7 +4,7 @@ describe "Egads::Build" do
   subject { Egads::Build }
 
   it 'should run the correct tasks' do
-    subject.commands.keys.must_equal %w(check_build run_before_build_hooks write_revision_file commit_extra_paths make_tarball run_after_build_hooks upload push_seed)
+    subject.commands.keys.must_equal %w(check_build run_before_build_hooks write_revision_file commit_extra_paths make_tarball run_after_build_hooks upload)
   end
 
   it 'takes one argument' do


### PR DESCRIPTION
## What

This change obviates the need for `seed` builds, allowing us to use faster shallow clones in CI.

## Background

Early in egads life (#1), we wanted to optimize the size of the artifact we uploaded to S3 b/c office bandwidth was slow. So we made daily "seed" builds that were large, complete artifacts; most artifacts were smaller "patch" builds agains that seed. As a side effect, that meant that we could no longer use shallow git clones on CI to make the patch (since we needed the seed commit too).

Shallow clones take ~10-15s on CI. Full clones take ~1.5-5min. 🙆 

The drawback (which seems acceptable) is our artifacts are each ~300MB rather than just a few megabytes.

## How

This PR basically reverts #1.

On the build side, we no longer diff against the seed build. Instead, each artifact is a complete build.

On the deploy side, when a server extracts an artifact, it looks for the `egads-seed` file to indicate whether it should apply the patch against the seed (the old style); or if the artifact is complete (new style).

## Deployment

1. To roll this out, we should first upgrade our deployed servers to use `v5.0.0` (which can deploy both old- and new-style artifacts).
2. Then we upgrade our Gemfile to use `v5.0.0` so we start making new style builds.
3. Switch our CI config to use faster shallow clones. Profit!

:wave: @lovehandle @kickstarter/platform, @kickstarter/devops 
