### PR TITLE
Explicitly require fileutils and bump version

### DIFF
--- a/lib/egads.rb
+++ b/lib/egads.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'yaml'
 require 'aws-sdk'
 require 'thor'

--- a/lib/egads/version.rb
+++ b/lib/egads/version.rb
@@ -1,3 +1,3 @@
 module Egads
-  VERSION = '5.0.0'
+  VERSION = '5.0.1'
 end


### PR DESCRIPTION
## What 

Require fileutils explicitly and bump the version.

## Why

Deployments not possible currently without the direct require. This used to be required by bundler, but in `1.15.4` this is not the case. 

https://github.com/kickstarter/chef-repo/pull/324

## CC

@ktheory 