### PR TITLE
Update aws sdk usage to use v3 sdk and s3 gem.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 sudo: false # Opt-in to container infrastructure
 rvm:
-  - 2.2.4
-  - 2.3.0
   - 2.5.5
   - 2.6.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ sudo: false # Opt-in to container infrastructure
 rvm:
   - 2.2.4
   - 2.3.0
+  - 2.5.5
+  - 2.6.3

--- a/egads.gemspec
+++ b/egads.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "README.md" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.add_dependency "aws-sdk", '~> 2.2', '>= 2.2.9'
+  s.add_dependency "aws-sdk-s3", '~> 1.0'
   s.add_dependency "thor"
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest"

--- a/lib/egads.rb
+++ b/lib/egads.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 require 'yaml'
-require 'aws-sdk'
+require 'aws-sdk-s3'
 require 'thor'
 require 'benchmark'
 require 'pathname'

--- a/lib/egads/version.rb
+++ b/lib/egads/version.rb
@@ -1,3 +1,3 @@
 module Egads
-  VERSION = '5.0.1'
+  VERSION = '5.1.0'
 end


### PR DESCRIPTION
# What

Updates the aws-sdk dependency to use the newer v3 version of the SDK and specifically just the S3 gem since that's all egads uses.

Also put some current ruby versions in the Travis CI config.

Can we removed the EOL'd ruby versions?

# Why

Downstream projects that rely on egads would like the option of running the v3 version of the sdk.

# Who
@frewsxcv + @kickstarter/infrastructure 