### PR TITLE
`File.exists?` -> `File.exist?`

### DIFF
--- a/lib/egads/command/extract.rb
+++ b/lib/egads/command/extract.rb
@@ -104,7 +104,7 @@ module Egads
     end
 
     def should_download?(path)
-      options[:force] || File.zero?(path) || !File.exists?(path)
+      options[:force] || File.zero?(path) || !File.exist?(path)
     end
 
     def should_extract?

--- a/lib/egads/command/stage.rb
+++ b/lib/egads/command/stage.rb
@@ -66,7 +66,7 @@ module Egads
     end
 
     def should_stage?
-      options[:force] || !File.exists?(stage_flag_path)
+      options[:force] || !File.exist?(stage_flag_path)
     end
 
     def shared_path
@@ -74,5 +74,3 @@ module Egads
     end
   end
 end
-
-


### PR DESCRIPTION
<img width="380" alt="Screenshot 2023-09-07 at 6 16 41 PM" src="https://github.com/kickstarter/egads/assets/9829542/0a19af55-a8e7-4fc8-b90e-f507f94a9a05">

Changed `File.exists?` to `File.exist?`.  This is necessary for the [Ruby 3.2](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) upgrade.

`File.exists?` has been deprecated since Ruby 2.2, so this change is safe for all Ruby versions we care about.